### PR TITLE
Codecov: Exclude tests that rely on secrets from codecov analysis

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,12 @@ codecov:
   notify:
     wait_for_ci: false
     after_n_builds: 1
+ignore:
+  # Ignore test that requires set up of 
+  # the conda environment and is not included
+  # in the coverage report collected in the standard way
+  - "primo/demo/tests/test_demo.py"
+  # Ignore tests that rely on secrets which are 
+  # not passed to incoming PRs to avoid false 
+  # alarm on reduced coverage
+  - "primo/utils/tests/test_secrets.py"

--- a/primo/utils/tests/test_census_utils.py
+++ b/primo/utils/tests/test_census_utils.py
@@ -18,12 +18,10 @@ import pytest
 from primo.utils.census_utils import (
     get_block,
     get_block_group,
-    get_census_key,
     get_county,
     get_fips_code,
     get_state,
     get_tract,
-    CensusClient,
 )
 
 
@@ -79,17 +77,3 @@ def test_get_block():
 
 def test_get_fips_code():
     assert get_fips_code(41, -76) == "420792166011027"
-
-
-@pytest.mark.secrets
-def test_generate_geo_identifiers():
-    CENSUS_KEY = get_census_key()
-    client = CensusClient(CENSUS_KEY)
-    generate_identifiers = client._generate_geo_identifiers
-    assert generate_identifiers("42") == ("state:42", "")
-    assert generate_identifiers("") == ("", "")
-    assert generate_identifiers("42079") == ("county:079", "state:42")
-    assert generate_identifiers("42079216601") == (
-        "tract:216601",
-        "state:42 county:079",
-    )

--- a/primo/utils/tests/test_demo_utils.py
+++ b/primo/utils/tests/test_demo_utils.py
@@ -23,7 +23,6 @@ from primo.utils.demo_utils import (
     file_path_widget,
     file_upload_widget,
     generate_configurations,
-    get_population_by_state,
     get_well_depth,
     get_well_type,
     priority_by_value,
@@ -202,24 +201,6 @@ def test_sort_by_disadvantaged_community_impact():
     assert "Disadvantaged area %" not in result_df.columns
     assert "Disadvantaged pop %" not in result_df.columns
     assert result_df["Disadvantaged Community"].idxmax() == 0
-
-
-# Sample state code for testing. 37 stands for North Carolina
-STATE_CODE = 37
-STATE_CODE_FAKE = 60
-
-
-@pytest.mark.secrets
-def test_get_population_by_state():
-    result_df = get_population_by_state(STATE_CODE)
-    assert "Total Population" in result_df.columns
-    assert result_df["state"].dtypes == int
-    assert result_df["county"].dtypes == int
-    assert result_df["tract"].dtypes == int
-    assert result_df["Total Population"].dtypes == int
-
-    with pytest.raises(AssertionError):
-        get_population_by_state(STATE_CODE_FAKE)
 
 
 def test_file_path_widget():

--- a/primo/utils/tests/test_elevation_utils.py
+++ b/primo/utils/tests/test_elevation_utils.py
@@ -16,19 +16,7 @@ import numpy as np
 import pytest
 
 # User defined libs
-from primo.utils.elevation_utils import (
-    accessibility,
-    get_bing_maps_api_key,
-    get_nearest_road_point,
-    get_route,
-    haversine_distance,
-)
-
-
-@pytest.mark.secrets
-def test_get_bing_maps_api_key():
-    key = get_bing_maps_api_key()
-    assert len(key) == 64
+from primo.utils.elevation_utils import haversine_distance
 
 
 @pytest.mark.parametrize(
@@ -64,94 +52,6 @@ def test_haversine_distance(lat1, lon1, lat2, lon2, return_value, status):
         )
     else:
         assert np.isnan(haversine_distance(lat1, lon1, lat2, lon2))
-
-
-@pytest.mark.parametrize(
-    "start_coord, end_coord, status",
-    [  # Case 1: pass case
-        (
-            [40.589335, -79.92741],
-            [40.642804, -79.715295],
-            True,
-        ),
-        # Case 2: missing data
-        (
-            [np.nan, -79.92741],
-            [40.642804, -79.715295],
-            False,
-        ),
-        # Add more test cases as needed
-    ],
-)
-@pytest.mark.secrets
-def test_get_route(start_coord, end_coord, status):
-    key = get_bing_maps_api_key()
-    if status:
-        assert isinstance(get_route(key, start_coord, end_coord), dict)
-        assert "routePath" in get_route(key, start_coord, end_coord)
-    else:
-        assert get_route(key, start_coord, end_coord) is None
-
-
-@pytest.mark.parametrize(
-    "lat, lon, return_tuple, status",
-    [  # Case 1: pass case
-        (
-            40.589335,
-            -79.92741,
-            (40.589202, -79.927406),
-            True,
-        ),
-        # Case 2: missing data
-        (
-            np.nan,
-            -79.92741,
-            "Error",
-            False,
-        ),
-        # Add more test cases as needed
-    ],
-)
-@pytest.mark.secrets
-def test_get_nearest_road_point(lat, lon, return_tuple, status):
-    if status:
-        assert np.allclose(
-            get_nearest_road_point(lat, lon),
-            return_tuple,
-            rtol=1e-5,
-            atol=1e-8,
-        )
-    else:
-        with pytest.raises(ValueError):
-            get_nearest_road_point(lat, lon)
-
-
-@pytest.mark.parametrize(
-    "lat, lon, return_value, status",
-    [  # Case 1: pass case
-        (40.4309, -79.739699, 0.033497882662451864, True),
-        # Case 2: missing data
-        (
-            np.nan,
-            -79.92741,
-            "Error",
-            False,
-        ),
-        # Add more test cases as needed
-    ],
-)
-@pytest.mark.secrets
-def test_accessibility(lat, lon, return_value, status):
-    if status:
-        assert np.isclose(
-            accessibility(lat, lon),
-            return_value,
-            rtol=1e-5,
-            atol=1e-8,
-        )
-    else:
-        with pytest.raises(ValueError):
-            accessibility(lat, lon)
 
 
 # TODO: Need a small test raster file for testing the get_elevation

--- a/primo/utils/tests/test_secrets.py
+++ b/primo/utils/tests/test_secrets.py
@@ -1,0 +1,160 @@
+#################################################################################
+# PRIMO - The P&A Project Optimizer was produced under the Methane Emissions
+# Reduction Program (MERP) and National Energy Technology Laboratory's (NETL)
+# National Emissions Reduction Initiative (NEMRI).
+#
+# NOTICE. This Software was developed under funding from the U.S. Government
+# and the U.S. Government consequently retains certain rights. As such, the
+# U.S. Government has been granted for itself and others acting on its behalf
+# a paid-up, nonexclusive, irrevocable, worldwide license in the Software to
+# reproduce, distribute copies to the public, prepare derivative works, and
+# perform publicly and display publicly, and to permit others to do so.
+#################################################################################
+
+"""
+GitHub secrets are not passed to PRs: Therefore all tests that rely on secrets
+must be turned off when Actions are run for an incoming PR. This in turn leads to
+codecov complaining about reduced coverage with a patch. 
+
+Thus all tests that rely on secrets are implemented in this single file which is 
+ignored for codecov analysis by suitably setting ignore paths in codecov.yml
+"""
+
+# Installed libs
+import numpy as np
+import pytest
+
+# User defined lib
+from primo.utils.census_utils import get_census_key, CensusClient
+from primo.utils.demo_utils import get_population_by_state
+from primo.utils.elevation_utils import (
+    accessibility,
+    get_bing_maps_api_key,
+    get_nearest_road_point,
+    get_route,
+)
+
+# Sample state code for testing. 37 stands for North Carolina
+STATE_CODE = 37
+STATE_CODE_FAKE = 60
+
+
+@pytest.mark.secrets
+def test_generate_geo_identifiers():
+    census_key = get_census_key()
+    client = CensusClient(census_key)
+    generate_identifiers = client._generate_geo_identifiers
+    assert generate_identifiers("42") == ("state:42", "")
+    assert generate_identifiers("") == ("", "")
+    assert generate_identifiers("42079") == ("county:079", "state:42")
+    assert generate_identifiers("42079216601") == (
+        "tract:216601",
+        "state:42 county:079",
+    )
+
+
+@pytest.mark.secrets
+def test_get_population_by_state():
+    result_df = get_population_by_state(STATE_CODE)
+    assert "Total Population" in result_df.columns
+    assert result_df["state"].dtypes == int
+    assert result_df["county"].dtypes == int
+    assert result_df["tract"].dtypes == int
+    assert result_df["Total Population"].dtypes == int
+
+    with pytest.raises(AssertionError):
+        get_population_by_state(STATE_CODE_FAKE)
+
+
+@pytest.mark.secrets
+def test_get_bing_maps_api_key():
+    key = get_bing_maps_api_key()
+    assert len(key) == 64
+
+
+@pytest.mark.parametrize(
+    "start_coord, end_coord, status",
+    [  # Case 1: pass case
+        (
+            [40.589335, -79.92741],
+            [40.642804, -79.715295],
+            True,
+        ),
+        # Case 2: missing data
+        (
+            [np.nan, -79.92741],
+            [40.642804, -79.715295],
+            False,
+        ),
+        # Add more test cases as needed
+    ],
+)
+@pytest.mark.secrets
+def test_get_route(start_coord, end_coord, status):
+    key = get_bing_maps_api_key()
+    if status:
+        assert isinstance(get_route(key, start_coord, end_coord), dict)
+        assert "routePath" in get_route(key, start_coord, end_coord)
+    else:
+        assert get_route(key, start_coord, end_coord) is None
+
+
+@pytest.mark.parametrize(
+    "lat, lon, return_tuple, status",
+    [  # Case 1: pass case
+        (
+            40.589335,
+            -79.92741,
+            (40.589202, -79.927406),
+            True,
+        ),
+        # Case 2: missing data
+        (
+            np.nan,
+            -79.92741,
+            "Error",
+            False,
+        ),
+        # Add more test cases as needed
+    ],
+)
+@pytest.mark.secrets
+def test_get_nearest_road_point(lat, lon, return_tuple, status):
+    if status:
+        assert np.allclose(
+            get_nearest_road_point(lat, lon),
+            return_tuple,
+            rtol=1e-5,
+            atol=1e-8,
+        )
+    else:
+        with pytest.raises(ValueError):
+            get_nearest_road_point(lat, lon)
+
+
+@pytest.mark.parametrize(
+    "lat, lon, return_value, status",
+    [  # Case 1: pass case
+        (40.4309, -79.739699, 0.033497882662451864, True),
+        # Case 2: missing data
+        (
+            np.nan,
+            -79.92741,
+            "Error",
+            False,
+        ),
+        # Add more test cases as needed
+    ],
+)
+@pytest.mark.secrets
+def test_accessibility(lat, lon, return_value, status):
+    if status:
+        assert np.isclose(
+            accessibility(lat, lon),
+            return_value,
+            rtol=1e-5,
+            atol=1e-8,
+        )
+    else:
+        with pytest.raises(ValueError):
+            accessibility(lat, lon)


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

GitHub secrets are not passed to PRs: Therefore all tests that rely on secrets have been turned  off when Actions are run for an incoming PR. https://github.com/NEMRI-org/primo-optimizer/blob/cb449ce4713d96fe95fe9175a6d8c107b9dd19d4/.github/workflows/checks.yml#L72C1-L76C13

However, codecov complaining about reduced coverage with a patch since these tests are not run. This PR addresses the failed codecov check by excluding tests that rely on secrets and the demo for codecov analysis.

## Changes proposed in this PR:
- Move all tests that rely on secrets in a single file: `test_secrets.py`
- Set ignore paths in codecov.yml to exclude `test_secrets.py` and `test_demo.py`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
