### PR TITLE
Added `fill_missing_value` attribute in Metric class

### DIFF
--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -22,6 +22,10 @@ def test_allowfile_matches_if_present(staged: StagedFile, allowfile: AllowFile):
 
 MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
     "primo/data_parser/data_model.py": 8,
+    "primo/data_parser/default_data.py": 41,
+    "primo/data_parser/metric_data.py": 15,
+    "primo/data_parser/tests/test_metric_data.py": 50,
+    "primo/data_parser/tests/test_well_data_column_names.py": 13,
     "docs/conf.py": 4,
     "primo/opt_model/base_model.py": 15,
     "primo/opt_model/opt_model.py": 15,

--- a/primo/data_parser/default_data.py
+++ b/primo/data_parser/default_data.py
@@ -15,6 +15,9 @@
 from dataclasses import dataclass
 from typing import Union
 
+# Installed libs
+from pyomo.common.config import Bool, NonNegativeFloat, NonNegativeInt
+
 # This file should contain all the constants
 FEASIBILITY_TOLERANCE = 1e-6  # Optimization Feasibility tolerance
 EARTH_RADIUS = 3959.0  # Earth's radius in Miles
@@ -27,6 +30,7 @@ START_COORDINATES = (40.44, -79.94)
 
 # Set of supported impact metrics along with
 # the required data for the analysis.
+# pylint: disable = too-many-instance-attributes
 @dataclass()
 class _SupportedContent:
     name: str
@@ -38,6 +42,10 @@ class _SupportedContent:
     # This will be used to check if the input data has
     # required columns or not.
     required_data: Union[str, list, None] = None
+    # Is the value of this metric inversly proportional to plugging priority?
+    # E.g., Compliance, production volume, well integrity, etc.
+    has_inverse_priority: bool = False
+    fill_missing_value: Union[None, dict] = None
 
 
 SUPP_IMPACT_METRICS = {
@@ -57,9 +65,14 @@ SUPP_IMPACT_METRICS = {
         full_name="Sensitive Receptors",
         has_submetrics=True,
     ),
-    "production_volume": _SupportedContent(
-        name="production_volume",
-        full_name="Production Volume",
+    "ann_production_volume": _SupportedContent(
+        name="ann_production_volume",
+        full_name="Annual Production Volume",
+        has_submetrics=True,
+    ),
+    "five_year_production_volume": _SupportedContent(
+        name="five_year_production_volume",
+        full_name="Five-year Production Volume",
         has_submetrics=True,
     ),
     "well_age": _SupportedContent(
@@ -79,8 +92,12 @@ SUPP_IMPACT_METRICS = {
     ),
     "well_integrity": _SupportedContent(
         name="well_integrity",
-        full_name="Hazards due to Well Integrity",
+        full_name="Is Well Integrity good?",
         required_data="well_integrity",
+        # Priority should be higher if well integrity is not good
+        has_inverse_priority=True,
+        # If it is not specified, assume that the well integrity is good
+        fill_missing_value={"domain": Bool, "default": True},
     ),
     "environment": _SupportedContent(
         name="environment",
@@ -94,6 +111,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="ch4_emissions",
         required_data="leak",
+        # Assume that the well is not leaking if it not specified
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "compliance": _SupportedContent(
         name="compliance",
@@ -101,6 +120,10 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="ch4_emissions",
         required_data="compliance",
+        # Priority should be higher if the well is not compliant
+        has_inverse_priority=True,
+        # Assuming well is compliant if it is not specified
+        fill_missing_value={"domain": Bool, "default": True},
     ),
     "violation": _SupportedContent(
         name="violation",
@@ -108,6 +131,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="ch4_emissions",
         required_data="violation",
+        # Assuming that the well is not in violation
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "incident": _SupportedContent(
         name="incident",
@@ -115,6 +140,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="ch4_emissions",
         required_data="incident",
+        # Incident is assumed to be False if it is not specified
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     # Submetrics of dac_impact
     "fed_dac": _SupportedContent(
@@ -131,6 +158,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="dac_impact",
         required_data="state_dac",
+        # If it is not specified, set the state DAC priority to zero
+        fill_missing_value={"domain": NonNegativeFloat, "default": 0},
     ),
     # Submetrics of sensitive_recptors
     "hospitals": _SupportedContent(
@@ -139,6 +168,7 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="sensitive_receptors",
         required_data="hospitals",
+        fill_missing_value={"domain": NonNegativeInt, "default": 0},
     ),
     "schools": _SupportedContent(
         name="schools",
@@ -146,6 +176,7 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="sensitive_receptors",
         required_data="schools",
+        fill_missing_value={"domain": NonNegativeInt, "default": 0},
     ),
     "buildings_near": _SupportedContent(
         name="buildings_near",
@@ -153,6 +184,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="sensitive_receptors",
         required_data="buildings_near",
+        # Assuming that no buildings are nearby if it is not specified
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "buildings_far": _SupportedContent(
         name="buildings_far",
@@ -160,6 +193,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="sensitive_receptors",
         required_data="buildings_far",
+        # Assuming no distant buildings
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     # Submetrics of environment
     "fed_wetlands_near": _SupportedContent(
@@ -168,6 +203,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="environment",
         required_data="fed_wetlands_near",
+        # Assuming no nearby federal wetlands
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "fed_wetlands_far": _SupportedContent(
         name="fed_wetlands_far",
@@ -175,6 +212,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="environment",
         required_data="fed_wetlands_far",
+        # Assuming no distant federal wetlands
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "state_wetlands_near": _SupportedContent(
         name="state_wetlands_near",
@@ -182,6 +221,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="environment",
         required_data="state_wetlands_near",
+        # Assuming no nearby state wetlands
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "state_wetlands_far": _SupportedContent(
         name="state_wetlands_far",
@@ -189,27 +230,53 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="environment",
         required_data="state_wetlands_far",
+        # Assuming no distant state wetlands
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     # Submetrics of production_volume
-    "ann_production_volume": _SupportedContent(
-        name="ann_production_volume",
-        full_name="Annual Production Volume",
+    "ann_gas_production": _SupportedContent(
+        name="ann_gas_production",
+        full_name="Annual Gas Production [in Mcf/Year]",
         is_submetric=True,
-        parent_metric="production_volume",
-        required_data=[
-            "ann_gas_production",
-            "ann_oil_production",
-        ],
+        parent_metric="ann_production_volume",
+        required_data="ann_gas_production",
+        # Higher gas production => lower priority for plugging
+        has_inverse_priority=True,
+        # Assuming that well is not producing gas, if it is not specified
+        fill_missing_value={"domain": NonNegativeFloat, "default": 0.0},
     ),
-    "five_year_production_volume": _SupportedContent(
-        name="five_year_production_volume",
-        full_name="Five-year Production Volume",
+    "ann_oil_production": _SupportedContent(
+        name="ann_oil_production",
+        full_name="Annual Oil Production [in bbl/Year]",
         is_submetric=True,
-        parent_metric="production_volume",
-        required_data=[
-            "five_year_gas_production",
-            "five_year_oil_production",
-        ],
+        parent_metric="ann_production_volume",
+        required_data="ann_oil_production",
+        # Higher oil production => lower priority for plugging
+        has_inverse_priority=True,
+        # Assuming that well is not producing oil, if it is not specified
+        fill_missing_value={"domain": NonNegativeFloat, "default": 0.0},
+    ),
+    "five_year_gas_production": _SupportedContent(
+        name="five_year_gas_production",
+        full_name="Five-year Gas Production [in Mcf]",
+        is_submetric=True,
+        parent_metric="five_year_production_volume",
+        required_data="five_year_gas_production",
+        # Higher gas production => lower priority for plugging
+        has_inverse_priority=True,
+        # Assuming that well is not producing gas, if it is not specified
+        fill_missing_value={"domain": NonNegativeFloat, "default": 0.0},
+    ),
+    "five_year_oil_production": _SupportedContent(
+        name="five_year_oil_production",
+        full_name="Five-year Oil Production [in bbl]",
+        is_submetric=True,
+        parent_metric="five_year_production_volume",
+        required_data="five_year_oil_production",
+        # Higher oil production => lower priority for plugging
+        has_inverse_priority=True,
+        # Assuming that well is not producing oil, if it is not specified
+        fill_missing_value={"domain": NonNegativeFloat, "default": 0.0},
     ),
     # Submetrics of other_emissions
     "h2s_leak": _SupportedContent(
@@ -218,6 +285,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="other_emissions",
         required_data="h2s_leak",
+        # Assuming no H2S leak if it is not specified
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "brine_leak": _SupportedContent(
         name="brine_leak",
@@ -225,6 +294,8 @@ SUPP_IMPACT_METRICS = {
         is_submetric=True,
         parent_metric="other_emissions",
         required_data="brine_leak",
+        # Assuming no brine leak if it is not specified
+        fill_missing_value={"domain": Bool, "default": False},
     ),
 }
 

--- a/primo/data_parser/default_data.py
+++ b/primo/data_parser/default_data.py
@@ -43,7 +43,7 @@ class _SupportedContent:
     # required columns or not.
     required_data: Union[str, list, None] = None
     # Is the value of this metric inversly proportional to plugging priority?
-    # E.g., Compliance, production volume, well integrity, etc.
+    # E.g., Compliance, production volume, etc.
     has_inverse_priority: bool = False
     fill_missing_value: Union[None, dict] = None
 
@@ -92,12 +92,10 @@ SUPP_IMPACT_METRICS = {
     ),
     "well_integrity": _SupportedContent(
         name="well_integrity",
-        full_name="Is Well Integrity good?",
+        full_name="Well Integrity Issues [Yes/No]",
         required_data="well_integrity",
-        # Priority should be higher if well integrity is not good
-        has_inverse_priority=True,
-        # If it is not specified, assume that the well integrity is good
-        fill_missing_value={"domain": Bool, "default": True},
+        # If it is not specified, assume no well integrity issues
+        fill_missing_value={"domain": Bool, "default": False},
     ),
     "environment": _SupportedContent(
         name="environment",

--- a/primo/data_parser/tests/test_well_data_column_names.py
+++ b/primo/data_parser/tests/test_well_data_column_names.py
@@ -41,27 +41,28 @@ def test_well_data_column_names():
     assert wcn.age == "Age [Years]"
     assert wcn.depth == "Depth [ft]"
 
-    # Testing contains and keys methods
+    # Testing contains, keys, and values methods
     for key in cols:
         assert key in wcn
-        assert key in wcn.keys()
+
+    assert wcn.keys() == cols
+    assert wcn.values() == [
+        "Well API",
+        "Latitude",
+        "Longitude",
+        "Age [Years]",
+        "Depth [ft]",
+    ]
 
     # Testing items method
     for key, val in wcn.items():
-        if key not in cols:
-            assert val is None
+        assert key in cols
+        assert val is not None
 
     # Testing iter method
     for key in wcn:
         if key not in cols:
             assert getattr(wcn, key) is None
-
-    # Testing values method
-    assert "Well API" in wcn.values()
-    assert "Latitude" in wcn.values()
-    assert "Longitude" in wcn.values()
-    assert "Age [Years]" in wcn.values()
-    assert "Depth [ft]" in wcn.values()
 
     # Test register new column method
     wcn.register_new_columns({"new_col_1": "New Column 1"})
@@ -79,8 +80,8 @@ def test_well_data_column_names():
         wcn.register_new_columns({"new col 3": "New Column 3"})
 
 
-@pytest.fixture(scope="module")
-def get_well_data_cols():
+@pytest.fixture(name="get_well_data_cols", scope="function")
+def get_well_data_cols_fixture():
     im_mt = ImpactMetrics()
     # Work with fewer metrics for convenience
     im_mt.delete_metric("environment")
@@ -99,7 +100,7 @@ def get_well_data_cols():
             "ch4_emissions": 20,
             "dac_impact": 20,
             "sensitive_receptors": 20,
-            "production_volume": 20,
+            "ann_production_volume": 20,
             "well_integrity": 20,
             # submetrics
             "leak": 50,
@@ -108,8 +109,8 @@ def get_well_data_cols():
             "state_dac": 60,
             "hospitals": 50,
             "schools": 50,
-            "ann_production_volume": 100,
-            "five_year_production_volume": 0,
+            "ann_gas_production": 40,
+            "ann_oil_production": 60,
         }
     )
 
@@ -201,46 +202,3 @@ def test_missing_col_error(get_well_data_cols):
         wcn.check_columns_available(im_mt)
 
     wcn.hospitals = "Hospitals"
-    # Now test the list of columns error message
-    wcn.ann_gas_production = None
-
-    with pytest.raises(
-        AttributeError,
-        match=(
-            "Weight of the metric ann_production_volume is nonzero, so attribute "
-            "ann_gas_production is an essential input in the WellDataColumnNames object."
-        ),
-    ):
-        wcn.check_columns_available(im_mt)
-
-    wcn.ann_gas_production = "Gas [Mcf/yr]"
-    wcn.ann_oil_production = None
-
-    with pytest.raises(
-        AttributeError,
-        match=(
-            "Weight of the metric ann_production_volume is nonzero, so attribute "
-            "ann_oil_production is an essential input in the WellDataColumnNames object."
-        ),
-    ):
-        wcn.check_columns_available(im_mt)
-
-    wcn.ann_oil_production = "Oil [bbl/yr]"
-
-    im_mt.set_weight(
-        {
-            "ann_production_volume": 50,
-            "five_year_production_volume": 50,
-        }
-    )
-    assert im_mt.check_validity() is None
-    wcn.five_year_gas_production = "Five-Year Gas [Mcf]"
-
-    with pytest.raises(
-        AttributeError,
-        match=(
-            "Weight of the metric five_year_production_volume is nonzero, so attribute "
-            "five_year_oil_production is an essential input in the WellDataColumnNames object."
-        ),
-    ):
-        wcn.check_columns_available(im_mt)

--- a/primo/data_parser/well_data_column_names.py
+++ b/primo/data_parser/well_data_column_names.py
@@ -62,7 +62,8 @@ class WellDataColumnNames:
     state_wetlands_far: Union[str, None] = None
 
     # Columns for production_volume metric
-    well_type: Union[str, None] = None
+    well_type: Union[str, None] = None  # Oil/Gas Type
+    well_type_by_depth: Union[str, None] = None  # Shallow/Deep Type
     ann_gas_production: Union[str, None] = None
     ann_oil_production: Union[str, None] = None
     five_year_gas_production: Union[str, None] = None
@@ -101,16 +102,19 @@ class WellDataColumnNames:
             setattr(self, key, val)
 
     def keys(self):
-        """Returns internal names of the columns"""
-        return self.__dict__.keys()
+        """Returns defined internal names of the columns"""
+        keys = [key for key, val in self.__dict__.items() if val is not None]
+        return keys
 
     def values(self):
-        """Returns user names of the columns"""
-        return self.__dict__.values()
+        """Returns user names of the columns that are not None"""
+        val = [val for val in self.__dict__.values() if val is not None]
+        return val
 
     def items(self):
         """Returns internal-user name pairs"""
-        return self.__dict__.items()
+        data = {key: val for key, val in self.__dict__.items() if val is not None}
+        return data.items()
 
     # pylint: disable = logging-fstring-interpolation
     def check_columns_available(
@@ -159,16 +163,3 @@ class WellDataColumnNames:
                 # Column name is specified, so continue to the next metric
                 # Register the column name in Metric object
                 obj.data_col_name = col_name
-                continue
-
-            # If the code reaches here, then _required_data must be a list.
-            # Currently, this happens only for production_volume metrics
-            # The `data_col_name` attribute will be assigned after processing
-            # the data production volume data
-            for col in obj._required_data:
-                if getattr(self, col) is None:
-                    msg = (
-                        f"Weight of the metric {obj.name} is nonzero, so attribute "
-                        f"{col} is an essential input in the WellDataColumnNames object."
-                    )
-                    raise_exception(msg, AttributeError)


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:
Added new attributes to the `Metric` class. These changes must be merged before #15. These changes help avoid duplication in `options_well_data.py` in #15 and also help in simplifying the code significantly. Opening a new PR, because I would like to have these changes in a separate commit.

## Changes proposed in this PR:
- Added `is_binary_type` attribute to identify metrics that take Yes/No values.
- Added `has_inverse_priority` attribute. For some metrics, a higher value implies a lower priority for plugging (e.g., compliance, production volume, etc.). This attribute helps in identifying those metrics.
- Added `fill_missing_value` property. This value will be used to fill the empty cells in the data corresponding to the metric.
- "ann_production_volume" metric requires both annual gas production rate and the annual oil production rate to compute the score. This was making the data input process slightly cumbersome. After the discussion during the daily standup, we have decided to make both gas production and oil production as individual submetrics. So, in this version, the `ann_production_volume` is made the primary metric and its submetrics are `ann_gas_production` and `ann_oil_production`.
- The `five_year_production_volume` metric is handled in a similar way.
- `well_data_column_names.py`: Updated the `keys`, `values`, and `items` method to yield only those attributes whose value is not `None`.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
