### PR TITLE
Accept 'both' as a valid well type when considering production type

### DIFF
--- a/primo/data_parser/well_data.py
+++ b/primo/data_parser/well_data.py
@@ -639,9 +639,18 @@ class WellData:
                     oil_wells.add(r)
                 elif self.data.loc[r, wt_col_name].lower() in "gas":
                     gas_wells.add(r)
+                elif self.data.loc[r, wt_col_name].lower() in "both":
+                    row = self.data.iloc[r]
+                    oil_prod = row[wcn.ann_oil_production]
+                    gas_prod = row[wcn.ann_gas_production]
+
+                    if oil_prod * CONVERSION_FACTOR > gas_prod:
+                        oil_wells.add(r)
+                    else:
+                        gas_wells.add(r)
                 else:
                     msg = (
-                        f"Well-type must be either oil or gas. Received "
+                        f"Well-type must be either oil or gas or both. Received "
                         f"{self.data.loc[r, wt_col_name]} in row {r}."
                     )
                     raise_exception(msg, ValueError)


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Some states may categorize wells by production as both (Producing both oil and gas). Accept both as input and then parse internally to classify well as "oil" or "gas" depending on what it produces more of.

## Changes proposed in this PR:
- Added "both" as a valid well type when considering production
- Added tests

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
