### PR TITLE
Make code numpy2.0 compatible

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -19,6 +19,7 @@ Jupyter
 LLC
 Mcf
 Namespace
+NaN
 Pyomo
 Pytest
 Quickstart
@@ -65,6 +66,7 @@ json
 libs
 msg
 multicommodity
+nanmean
 ndarray
 np
 num

--- a/primo/utils/kpi_utils.py
+++ b/primo/utils/kpi_utils.py
@@ -35,7 +35,8 @@ def _is_numeric_valid_column(
     column_name : str
         The column name for column under consideration
     estimation_method: str
-        "yes" if this being applied to a method that's estimating values, or "no" if it's anything else.
+        "yes" if this being applied to a method that's estimating values,
+        or "no" if it's anything else.
 
     Raises
     ------
@@ -114,7 +115,8 @@ def calculate_average(
     column_name: str
         The column name of the specified metric for calculation
     estimation_method: str
-        "yes" if this being applied to a method that's estimating values, or "no" if it's anything else
+        "yes" if this being applied to a method that's estimating values,
+        or "no" if it's anything else
 
     Returns
     -------
@@ -129,12 +131,12 @@ def calculate_average(
     """
     _is_numeric_valid_column(group, column_name, estimation_method)
 
-    # If all values in the column are NaN, a runtime warning is raised by np.nanmean
+    # If all values in the column are NaN, a run time warning is raised by np.nanmean
     col = np.abs(group[column_name])
     if pd.isna(col).all():
-        return np.NaN
-    else:
-        return np.nanmean(col)
+        return np.nan
+
+    return np.nanmean(col)
 
 
 def calculate_number_of_owners(group: pd.DataFrame) -> int:
@@ -159,6 +161,7 @@ def calculate_number_of_owners(group: pd.DataFrame) -> int:
     return len(set(group["Operator Name"]))
 
 
+# pylint: disable=too-many-locals
 def process_data(merged_df: pd.DataFrame, centroids: dict) -> pd.DataFrame:
     """
     Process the merged DataFrame to compute various statistics for each project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "kneed",
     "matplotlib",
     "notebook",
-    "numpy<=1.28",
+    "numpy",
     "openpyxl",
     "pandas",
     "pyarrow",


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Numpy was previously pinned to 1.28 to make sure it would work with pyomo. Now that pyomo has fixed compatibility issues with 2.0, we can update our dependency requirement

## Changes proposed in this PR:
- numpy 2.0 is now supported by PRIMO
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
