### PR TITLE
Fixing the Error With OptModelInputs Class When Calculating Well Owner Count

### DIFF
--- a/primo/opt_model/model_options.py
+++ b/primo/opt_model/model_options.py
@@ -206,14 +206,15 @@ class OptModelInputs:  # pylint: disable=too-many-instance-attributes
         self.pairwise_depth_difference = self._pairwise_matrix(metric="depth")
 
         # Construct owner well count data
-        operator_list = set(wd[col_names.operator_name])
-        self.owner_well_count = {owner: [] for owner in operator_list}
-        for well in wd:
-            # {Owner 1: [(c1, i2), (c1, i3), (c4, i7), ...], ...}
-            # Key => Owner name, Tuple[0] => cluster, Tuple[1] => index
-            self.owner_well_count[wd.data.loc[well, col_names.operator_name]].append(
-                (wd.data.loc[well, col_names.cluster], well)
-            )
+        if wd.config.ignore_operator_name:
+            operator_list = set(wd[col_names.operator_name])
+            self.owner_well_count = {owner: [] for owner in operator_list}
+            for well in wd:
+                # {Owner 1: [(c1, i2), (c1, i3), (c4, i7), ...], ...}
+                # Key => Owner name, Tuple[0] => cluster, Tuple[1] => index
+                self.owner_well_count[
+                    wd.data.loc[well, col_names.operator_name]
+                ].append((wd.data.loc[well, col_names.cluster], well))
 
         # NOTE: Attributes _opt_model and _solver are defined in
         # build_optimization_model and solve_model methods, respectively.


### PR DESCRIPTION
…se the tool still tries to calculate owner well count.

## Fixes/Addresses/Summary/Motivation:

This PR is to address the error that occurs when a user specifies False for ignore_operator_name and doesn't supply the tool with operator name data, but the tool still attempts to calculate well owner count through the initialization of the OptModelInputs class. 

## Changes proposed in this PR:
-  init method under the OptModelInputs Class
       - Added a flag at line 209 to check for  ignore_operator_name  = False before calculating well owner count

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
