### PR TITLE
Fix Duplicate Well Data in `OverrideCampaign` When Reassigning Selected Wells without First Removing Them

### DIFF
--- a/primo/utils/config_utils.py
+++ b/primo/utils/config_utils.py
@@ -834,6 +834,12 @@ class SelectWidgetAdd(SelectWidget):
                 ]  # Update to the cluster of the selected well
 
     def _add(self, _) -> None:
+        if self._text not in self.wd.data[self.wd._col_names.well_id].values:
+            raise_exception(
+                "The well is already assigned to a project. It must be removed "
+                "from the current project before it can be assigned to another one.",
+                ValueError,
+            )
         super()._add(_)
         well_index = self.wd.data[
             self.wd.data[self.wd._col_names.well_id] == self._text

--- a/primo/utils/override_utils.py
+++ b/primo/utils/override_utils.py
@@ -219,6 +219,8 @@ class OverrideCampaign:
         self.plug_list = []
         for _, well_list in self.new_campaign.items():
             self.plug_list += well_list
+        # prevent duplication in plug_list
+        self.plug_list = list(set(self.plug_list))
         self.wd = self.opt_inputs.config.well_data._construct_sub_data(self.plug_list)
 
         self.feasibility = AssessFeasibility(

--- a/primo/utils/tests/test_config_utils.py
+++ b/primo/utils/tests/test_config_utils.py
@@ -471,7 +471,6 @@ def test_user_selection(
 
     # Withdraw None
     or_wid_class.add_widget._text = ""
-    page_session.get_by_label("Add Well").fill("")
     with pytest.raises(ValueError, match="Nothing selected, cannot remove from list"):
         or_wid_class.add_widget._remove(None)
 
@@ -487,6 +486,16 @@ def test_user_selection(
     or_wid_class.add_widget._remove("69254")
     assert or_wid_class.add_widget.selected_list == ["94343"]
     assert or_wid_class.add_widget.re_cluster_dict == {1: [80], 6: []}
+
+    # Add well 69687, index 807, which has been selected
+    or_wid_class.add_widget._text = "69687"
+    with pytest.raises(
+        ValueError,
+        match="The well is already assigned to a project. "
+        "It must be removed from the current project before it can be "
+        "assigned to another one.",
+    ):
+        or_wid_class.add_widget._add(None)
 
     # Lock project 19
     page_session.wait_for_timeout(2000)

--- a/primo/utils/tests/test_override_utils.py
+++ b/primo/utils/tests/test_override_utils.py
@@ -279,8 +279,8 @@ def or_infeasible_distance_selection_fixture():
     """
     project_remove = [13]
     well_remove = {1: [851]}
-    well_add_existing_cluster = {1: [851]}
-    well_add_new_cluster = {11: [851]}
+    well_add_existing_cluster = {1: [851, 807]}
+    well_add_new_cluster = {11: [851], 36: [807]}
     project_lock = []
     well_lock = {}
     remove_widget_return = OverrideRemoveLockInfo(project_remove, well_remove)
@@ -294,8 +294,9 @@ def or_infeasible_distance_selection_fixture():
 
 def test_infeasible_distance(or_feasible_distance_selection, get_model):
     """
-    Test the override campaign class where the new projects violate
-    the distance constraint after the override step
+    Test the override campaign class where (1) the new projects violate
+    the distance constraint after the override step (2) A well is not removed
+    from the recommended projects before being reassigned to another project
     """
     opt_campaign, opt_mdl_inputs, eff_metrics = get_model
     or_selection = or_feasible_distance_selection
@@ -303,6 +304,10 @@ def test_infeasible_distance(or_feasible_distance_selection, get_model):
     or_camp_class = OverrideCampaign(
         or_selection, opt_mdl_inputs, opt_campaign.clusters_dict, eff_metrics
     )
+
+    # Test if there is any duplication in the plug_list
+    assert 807 in or_camp_class.plug_list
+    assert or_camp_class.plug_list.count(807) == 1
 
     assert not or_camp_class.feasibility.assess_feasibility()
     assert or_camp_class.feasibility.assess_budget() < 0


### PR DESCRIPTION
…ted well is reassigned

## Fixes/Addresses/Summary/Motivation:

This PR addresses the issue of duplicated well data in the `OverrideCampaign` when a selected well is reassigned to another project during the "add well" step, without being removed beforehand.

## Changes proposed in this PR:
- An error message will be raised if a well, already selected in the optimization results, is reassigned to another project without first being removed from the current project.
- Remove any duplications in the `plug_list` before it is used to construct the sub-well data object.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
