### PR TITLE
Update validation check for longitude and corresponding tests

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -86,6 +86,8 @@ scikit
 shapefile
 shapefiles
 stacktrace
+stagedfright
+str
 sublicense
 submetric
 submetrics

--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -17,6 +17,9 @@ from stagedfright import AllowFile, PyContent, StagedFile
 
 
 def test_allowfile_matches_if_present(staged: StagedFile, allowfile: AllowFile):
+    """
+    Function to match fingerprints for allow files
+    """
     assert (
         staged.fingerprint == allowfile.fingerprint
     ), "An allowfile must contain a matching fingerprint for a staged file to be cleared for commit"
@@ -29,7 +32,7 @@ MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
     "primo/data_parser/metric_data.py": 15,
     "primo/data_parser/well_data.py": 40,
     "primo/data_parser/tests/test_metric_data.py": 50,
-    "primo/data_parser/tests/test_well_data.py": 203,
+    "primo/data_parser/tests/test_well_data.py": 237,
     "primo/data_parser/tests/test_well_data_columns.py": 13,
     "primo/data_parser/tests/test_well_data_common_methods.py": 73,
     "docs/conf.py": 4,
@@ -78,7 +81,7 @@ MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
 
 # this is meta, two levels deep:
 # - this file is also included checked by stagedfright,
-#   so the hardcoded data used to define this mapping must be counted,
+#   so the hard-coded data used to define this mapping must be counted,
 # - the extra number accounts for constants defined below,
 #   plus 1 for the fact that this number itself is defined using a constant
 MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT[".stagedfright/checks.py"] = (
@@ -86,8 +89,13 @@ MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT[".stagedfright/checks.py"] = (
 )
 
 
+# pylint: disable=missing-function-docstring
 @pytest.mark.usefixtures("skip_if_matching_allowfile")
 class TestIsClearedForCommit:
+    """
+    Class defining all the tests for files to pass the pre-commit hook for stagedfright
+    """
+
     def test_has_py_path_suffix(self, staged: StagedFile):
         assert staged.suffix in {
             ".py"

--- a/primo/data_parser/tests/test_well_data.py
+++ b/primo/data_parser/tests/test_well_data.py
@@ -94,9 +94,9 @@ def get_random_generator_fixture():
 @pytest.fixture(name="get_random_lat_long_bounds", scope="function")
 def get_random_lat_long_bounds_fixture():
     """
-    Provides a block randomly selected across the continental US
+    Provides a block randomly selected across the United States
     """
-    return (37.5, 39.2, -81.6, -81.5)
+    return (-113, -83, 33, 41)
 
 
 def test_dac_score(get_column_names, get_random_generator, get_random_lat_long_bounds):
@@ -154,8 +154,8 @@ def test_dac_score(get_column_names, get_random_generator, get_random_lat_long_b
     rng = get_random_generator
     bounds = get_random_lat_long_bounds
     (long_lo, long_hi, lat_lo, lat_hi) = get_random_lat_long_bounds
-    df["x"] = rng.uniform(long_lo, long_hi, len(df))
-    df["y"] = rng.uniform(lat_lo, lat_hi, len(df))
+    df["y"] = rng.uniform(long_lo, long_hi, len(df))
+    df["x"] = rng.uniform(lat_lo, lat_hi, len(df))
     wd = WellData(
         data=df,
         column_names=col_names,

--- a/primo/data_parser/well_data.py
+++ b/primo/data_parser/well_data.py
@@ -865,7 +865,7 @@ class WellData:
         # Assuming that no well is older than 350 year old
         # Assuming that no well is deeper than 40000 ft
         self.check_data_in_range(wcn.latitude, -90, 90)
-        self.check_data_in_range(wcn.longitude, -90, 90)
+        self.check_data_in_range(wcn.longitude, -180, 180)
         self.check_data_in_range(wcn.age, 0.0, 350.0)
         self.check_data_in_range(wcn.depth, 0.0, 40000.0)
 


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

The current codebase enforces that Longitudes be within [-90, 90], however the true range is [-180,180]. This change is necessary to process data from the state of Colorado (longitude = -103ish).

## Changes proposed in this PR:
- Change the validation of the longitude column to [-180,180]
- Update tests as appropriate.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
