### PR TITLE
Efficiency cut offs, single well efficiency scores, and plotting change 

### DIFF
--- a/primo/demo/PRIMO - Example_1.ipynb
+++ b/primo/demo/PRIMO - Example_1.ipynb
@@ -406,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "f9943664",
    "metadata": {},
    "outputs": [
@@ -431,8 +431,8 @@
     "# Construct an object to store column names\n",
     "col_names = WellDataColumnNames(\n",
     "    well_id=\"API Well Number\",\n",
-    "    latitude=\"x\",\n",
-    "    longitude=\"y\",\n",
+    "    latitude=\"y\",\n",
+    "    longitude=\"x\",\n",
     "    operator_name=\"Operator Name\",\n",
     "    age=\"Age [Years]\",\n",
     "    depth=\"Depth [ft]\",\n",
@@ -1393,7 +1393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "27fdb5a7",
    "metadata": {
     "jupyter": {
@@ -1427,8 +1427,8 @@
     "for cluster in color_list_gas:\n",
     "    gas_cluster = gas_wells[gas_wells[cluster_col_name] == cluster]\n",
     "    ax1.scatter(\n",
-    "        gas_cluster[col_names.latitude],\n",
     "        gas_cluster[col_names.longitude],\n",
+    "        gas_cluster[col_names.latitude],\n",
     "        c=color_list_gas[cluster],\n",
     "    )\n",
     "\n",
@@ -1438,8 +1438,8 @@
     "for cluster in color_list_oil:\n",
     "    oil_cluster = oil_wells[oil_wells[cluster_col_name] == cluster]\n",
     "    ax2.scatter(\n",
-    "        oil_cluster[col_names.latitude],\n",
     "        oil_cluster[col_names.longitude],\n",
+    "        oil_cluster[col_names.latitude],\n",
     "        c=color_list_oil[cluster],\n",
     "    )\n",
     "\n",

--- a/primo/opt_model/result_parser.py
+++ b/primo/opt_model/result_parser.py
@@ -278,8 +278,6 @@ class Project:
         value : Union[int, float]
             The value to update the efficiency score with
         """
-        if len(self.well_data) == 1:
-            return
         self.efficiency_score += value
 
     def get_well_info_dataframe(self):

--- a/primo/opt_model/result_parser.py
+++ b/primo/opt_model/result_parser.py
@@ -720,36 +720,32 @@ class EfficiencyCalculator:
                 setattr(
                     project,
                     metric.score_attribute,
-                    (
-                        max(
-                            0,
-                            min(
-                                (
-                                    (max_value - getattr(project, metric.name))
-                                    / (max_value - min_value)
-                                )
-                                * metric.effective_weight,
-                                metric.effective_weight,
+                    max(
+                        0,
+                        min(
+                            1,
+                            (
+                                (max_value - getattr(project, metric.name))
+                                / (max_value - min_value)
                             ),
                         ),
-                    ),
+                    )
+                    * metric.effective_weight,
                 )
 
             else:
                 setattr(
                     project,
                     metric.score_attribute,
-                    (
-                        max(
-                            0,
-                            min(
-                                (getattr(project, metric.name) - min_value)
-                                / (max_value - min_value)
-                                * metric.effective_weight,
-                                metric.effective_weight,
-                            ),
+                    max(
+                        0,
+                        min(
+                            1,
+                            (getattr(project, metric.name) - min_value)
+                            / (max_value - min_value),
                         ),
-                    ),
+                    )
+                    * metric.effective_weight,
                 )
 
     def compute_overall_efficiency_scores_project(self, project: Project):

--- a/primo/opt_model/result_parser.py
+++ b/primo/opt_model/result_parser.py
@@ -431,8 +431,8 @@ class Campaign:
         ax = plt.gca()
         for _, project in self.projects.items():
             ax.scatter(
-                project.well_data[project.col_names.latitude],
                 project.well_data[project.col_names.longitude],
+                project.well_data[project.col_names.latitude],
             )
         plt.title(title)
         plt.xlabel("x-coordinate of wells")
@@ -721,10 +721,18 @@ class EfficiencyCalculator:
                     project,
                     metric.score_attribute,
                     (
-                        (max_value - getattr(project, metric.name))
-                        / (max_value - min_value)
-                    )
-                    * metric.effective_weight,
+                        max(
+                            0,
+                            min(
+                                (
+                                    (max_value - getattr(project, metric.name))
+                                    / (max_value - min_value)
+                                )
+                                * metric.effective_weight,
+                                metric.effective_weight,
+                            ),
+                        ),
+                    ),
                 )
 
             else:
@@ -732,10 +740,16 @@ class EfficiencyCalculator:
                     project,
                     metric.score_attribute,
                     (
-                        (getattr(project, metric.name) - min_value)
-                        / (max_value - min_value)
-                    )
-                    * metric.effective_weight,
+                        max(
+                            0,
+                            min(
+                                (getattr(project, metric.name) - min_value)
+                                / (max_value - min_value)
+                                * metric.effective_weight,
+                                metric.effective_weight,
+                            ),
+                        ),
+                    ),
                 )
 
     def compute_overall_efficiency_scores_project(self, project: Project):

--- a/primo/opt_model/tests/test_result_parser.py
+++ b/primo/opt_model/tests/test_result_parser.py
@@ -523,7 +523,7 @@ def test_single_well(get_minimal_campaign, get_efficiency_metrics_minimal):
     )
     get_minimal_campaign.set_efficiency_weights(get_efficiency_metrics_minimal)
     get_minimal_campaign.efficiency_calculator.compute_efficiency_scores()
-    assert get_minimal_campaign.projects[3].efficiency_score == 0
+    assert get_minimal_campaign.projects[3].efficiency_score == 100
 
 
 def test_zeros(get_minimal_campaign, get_efficiency_metrics_minimal):


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:
These changes address minor issues observed in the demo notebook:
1. Latitude and longitude are switched (latitude should be on the y-axis and longitude on the x-axis)
Issue #50 : allowed full efficiency calculation for single well projects
Issue #29 : enforced a cutoff for the efficiency score metrics to restrict them to be between 0-weight

## Changes proposed in this PR:
- Various switching of latitude and longitude in the demo notebook and plotting functions (result_parser.py)
- Allowing efficiency calculations for single well projects
- Enforce efficiency metrics to fall within the range [0-weight]

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
