### PR TITLE
Publish on PyPI when an appropriate tag is created

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,71 @@
+name: Publish PRIMO release to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    if: startsWith(github.ref, 'refs/tags/')  # only build on tag pushes
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish PRIMO release to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/primo-optimizer
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish release to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  
+  publish-to-testpypi:
+    name: Publish PRIMO release to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/primo-optimizer
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish release to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/primo/__init__.py
+++ b/primo/__init__.py
@@ -11,5 +11,5 @@
 # perform publicly and display publicly, and to permit others to do so.
 #################################################################################
 
-RELEASE = "0.1.dev0"
-VERSION = "0.1"
+RELEASE = "0.2.0rc1"
+VERSION = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ platforms = ["windows", "linux"]
 py-modules = ["stagedfright"]
 
 [tool.setuptools.dynamic]
-version = {attr = "primo.VERSION"}
+version = {attr = "primo.RELEASE"}
 
 [tool.setuptools.packages.find]
 #where = [".", ".stagedfright"]


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Creates a workflow to push to PyPI and TestPyPI automatically when a GitHub tag is created to simply the process of pushing on those repositories

## Changes proposed in this PR:
- Update RELEASE to 0.2.0rc1 and VERSION to 0.2.0
- Include an automated workflow to push assets to pypi.org and testpypi.org

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
