### PR TITLE
Adding Flexibility to The Override Feature

### DIFF
--- a/primo/utils/config_utils.py
+++ b/primo/utils/config_utils.py
@@ -266,7 +266,7 @@ class CheckBoxWidget:
         The horizontal box that contains the checkbox and slider appended together
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=[too-many-arguments,too-many-positional-arguments]
         self,
         description: str,
         default: int,
@@ -675,11 +675,11 @@ class BaseSelectWidget:
         vbox.layout.align_items = "flex-end"
         return vbox, self.output
 
-    def return_selections(self) -> List[int]:
+    def return_selections(self):
         """
         Return the list of selections made by the user
         """
-        return [int(item) for item in self.selected_list]
+        return self.selected_list
 
     def _pass_current_selection(self):
         """
@@ -865,7 +865,7 @@ class SelectWidgetAdd(SelectWidget):
         vbox = widgets.HBox([vbox_left, vbox_right])
         return vbox, self.output
 
-    def return_selections(self) -> List[int]:
+    def return_selections(self):
         """
         Return the list of selections made by a user
         """

--- a/primo/utils/config_utils.py
+++ b/primo/utils/config_utils.py
@@ -549,6 +549,7 @@ class UserPriorities:
         return self.priorities_, self.sub_priorities_
 
 
+# pylint: disable = too-many-instance-attributes
 class BaseSelectWidget:
     """
     A base class for displaying an autofill widget in Jupyter Notebook to select multiple
@@ -565,6 +566,9 @@ class BaseSelectWidget:
 
     type_description: str
         The type of object (project or well) to be selected, displayed on the widget
+
+    max_options_displayed: int
+        The max number of options displayed for the override widgets
 
     Attributes
     ----------
@@ -587,6 +591,7 @@ class BaseSelectWidget:
 
     _text : str
         The current selection of the widget
+
     """
 
     def __init__(
@@ -594,8 +599,10 @@ class BaseSelectWidget:
         choices: List[int],
         button_description: str,
         type_description: str,
+        max_options_displayed: int,
     ):
         self.choices = [str(choice) for choice in choices]
+        self.max_options_displayed = max_options_displayed
 
         # Initialize text
         self._text = ""
@@ -628,7 +635,18 @@ class BaseSelectWidget:
         """
         self._text = data["new"]
 
-        self.widget.options = self.choices
+        if self.max_options_displayed is None:
+
+            self.widget.options = self.choices
+
+        else:
+            filtered = [well for well in self.choices if self._text in str(well)]
+
+            # Limit the number of displayed options (e.g., to the first 50)
+            limited_values = filtered[: self.max_options_displayed]
+
+            # Set the options of the Combobox to the limited list of matching well choices
+            self.widget.options = limited_values
 
     def _add(self, _) -> None:
         """
@@ -710,19 +728,29 @@ class SubSelectWidget(BaseSelectWidget):
 
     well_data : pd.DataFrame
         Data containing well information
+
+    max_options_displayed: int
+        The max number of options displayed for the override widgets
     """
 
+    # pylint: disable = too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         cluster_choices: List[int],
         button_description_cluster: str,
         button_description_well: str,
         well_data,
+        max_options_displayed: int,
     ):
-        super().__init__(cluster_choices, button_description_well, "Well")
+        super().__init__(
+            cluster_choices, button_description_well, "Well", max_options_displayed
+        )
         # set the widget for selecting clusters
         self.cluster_widget = SelectWidget(
-            cluster_choices, button_description_cluster, "Project"
+            cluster_choices,
+            button_description_cluster,
+            "Project",
+            max_options_displayed,
         )
         self.wd = well_data
 
@@ -763,6 +791,9 @@ class SelectWidgetAdd(SelectWidget):
     type_description : str
         Type of object to be selected
 
+    max_options_displayed: int
+        The max number of options displayed for the override widgets
+
     Attributes
     ----------
 
@@ -786,6 +817,7 @@ class SelectWidgetAdd(SelectWidget):
 
     selected_list : List[str]
         List containing all projects or wells selected by the user
+
     """
 
     # pylint: disable=protected-access
@@ -795,6 +827,7 @@ class SelectWidgetAdd(SelectWidget):
         well_choices,
         button_description: str,
         type_description: str,
+        max_options_displayed: int,
     ):
         self.wd = well_choices
         col_names = self.wd._col_names
@@ -802,6 +835,7 @@ class SelectWidgetAdd(SelectWidget):
             self.wd.data[self.wd._col_names.well_id],
             button_description,
             type_description,
+            max_options_displayed,
         )
 
         self.re_cluster = widgets.BoundedIntText(
@@ -883,13 +917,22 @@ class UserSelection:
 
     model_inputs: OptModelInputs
         Object containing the necessary inputs for the optimization model
+
+    max_options_displayed: int
+        The max number of options displayed for the override widgets
     """
 
     # pylint: disable=too-many-instance-attributes,protected-access
 
-    def __init__(self, opt_campaign: dict, model_inputs: object):
+    def __init__(
+        self,
+        opt_campaign: dict,
+        model_inputs: object,
+        max_options_displayed: int = None,
+    ):
         self.wd = model_inputs.config.well_data
         self.opt_campaign = opt_campaign
+        self.max_options_displayed = max_options_displayed
         self.well_selected_list = [
             well for wells in opt_campaign.values() for well in wells
         ]
@@ -904,10 +947,13 @@ class UserSelection:
             "Select projects to manually remove",
             "Select wells to manually remove",
             self.well_selected,
+            self.max_options_displayed,
         )
 
-        self.add_widget = SelectWidgetAdd(self.wd, "", "")
-        self.lock_widget = SubSelectWidget([], "", "", self.wd)
+        self.add_widget = SelectWidgetAdd(self.wd, "", "", self.max_options_displayed)
+        self.lock_widget = SubSelectWidget(
+            [], "", "", self.wd, self.max_options_displayed
+        )
 
         # Confirm button
         layout = widgets.Layout(width="auto", height="50%")
@@ -980,7 +1026,10 @@ class UserSelection:
         well_add_candidate = self.wd._construct_sub_data(well_add_candidate_list)
 
         self.add_widget = SelectWidgetAdd(
-            well_add_candidate, "Select wells to manually add", "Add Well"
+            well_add_candidate,
+            "Select wells to manually add",
+            "Add Well",
+            self.max_options_displayed,
         )
 
     def _set_lock_widget(self, remove_selections_cluster, remove_selections_well):
@@ -1003,6 +1052,7 @@ class UserSelection:
             "Select projects to manually lock",
             "Select wells to manually lock",
             self.well_lock_choice,
+            self.max_options_displayed,
         )
 
     def _display_all_widgets(self):

--- a/primo/utils/config_utils.py
+++ b/primo/utils/config_utils.py
@@ -640,7 +640,7 @@ class BaseSelectWidget:
             self.widget.options = self.choices
 
         else:
-            filtered = [well for well in self.choices if self._text in str(well)]
+            filtered = [choice for choice in self.choices if self._text in str(choice)]
 
             # Limit the number of displayed options (e.g., to the first 50)
             limited_values = filtered[: self.max_options_displayed]

--- a/primo/utils/override_utils.py
+++ b/primo/utils/override_utils.py
@@ -118,7 +118,7 @@ class AssessFeasibility:
             # When the user does not have owner information
             # or does not wish to prioritize
             # this constraint becomes meaningless
-            return 0
+            return {}
         violated_operators = {}
         for operator, groups in self.wd.data.groupby(self.wd._col_names.operator_name):
             n_wells = len(groups)

--- a/primo/utils/override_utils.py
+++ b/primo/utils/override_utils.py
@@ -112,6 +112,13 @@ class AssessFeasibility:
         Returns list of owners and wells selected for each for whom the owner
         well count constraint is violated
         """
+        opt_inputs = self.opt_inputs.config
+        max_wells_per_owner = opt_inputs.max_wells_per_owner
+        if max_wells_per_owner is None:
+            # When the user does not have owner information
+            # or does not wish to prioritize
+            # this constraint becomes meaningless
+            return 0
         violated_operators = {}
         for operator, groups in self.wd.data.groupby(self.wd._col_names.operator_name):
             n_wells = len(groups)

--- a/primo/utils/tests/test_config_utils.py
+++ b/primo/utils/tests/test_config_utils.py
@@ -369,6 +369,10 @@ def test_user_selection(
     """
     opt_campaign, opt_mdl_inputs, _ = get_model
 
+    or_wid_class_display_max_set = UserSelection(
+        opt_campaign.clusters_dict, opt_mdl_inputs, max_options_displayed=3
+    )
+
     or_wid_class = UserSelection(opt_campaign.clusters_dict, opt_mdl_inputs)
 
     # Test the structure of the override widget
@@ -385,6 +389,11 @@ def test_user_selection(
     assert isinstance(or_wid_class.lock_widget, SubSelectWidget)
     assert hasattr(or_wid_class.add_widget, "re_cluster")
     assert isinstance(or_wid_class.add_widget.re_cluster, widgets.BoundedIntText)
+
+    # When max_options_displayed is set to 3
+    assert 3 >= len(or_wid_class_display_max_set.add_widget.widget.options)
+    assert 3 >= len(or_wid_class_display_max_set.remove_widget.widget.options)
+    assert 3 >= len(or_wid_class_display_max_set.lock_widget.widget.options)
 
     or_wid_class.display()
 


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

This PR is to give the override feature more flexibility when it comes to the type of Well ID used and the number of options that gets displayed in the widgets.

## Changes proposed in this PR:
- override_utils.py
     - Made the assess_owner_well_count function run only when a user has selected a value for max_wells_per_owner
- config_utils.py
     -  Created a new input to the UserSelection class, max_options_displayed, that allows the user to set a max number of options 
         displayed when interacting with the widgets. Default is None.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
